### PR TITLE
Testing node and more refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
 planner/paths/*
+planner/test/logs/*
 !planner/paths/*.sh
 !planner/paths/*.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Noteable/major changes will be listed here
 
+## 31st Jan 2021
+
+### Added
+
+- modelStatesCallback(), startPlanSrvCallback(), and update() methods in Planner class. The update functions updates the collision boxes and goal state.
+- path_found, path_valid, grasp_sucess booleans, and plan_time to start_plan service.
+- Testing node to automate planner testing and logging data recieved from the service call.
+- Planner grasp attempt verification (i.e. grasp successful or not).
+
+### Modified
+
+- Planner class is now the main interfacing classs. It includes all other classes as members.
+- plan() method now takes no parameters.
+- planning time is now saved in seconds as a float64 variable.
+
+### Removed
+
+- statesCallback(), startPlanSrv(), and getCollisionBoxes() from Controller class, functionality moved to Planner class.
+
 ## 29th Jan 2021
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Noteable/major changes will be listed here
 
+## 3rd Feb 2021
+
+### Fixed
+
+- testing node overwriting log file rather than appending.
+  
+### Modified
+
+- testing node will call service to reset arm regardless if the arm moved or not.
+
 ## 31st Jan 2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,14 +100,13 @@ $ roslaunch planner gazebo.launch
 A Gazebo and Rviz windows should popup.
 
 If desired, you can pass in a world argument to launch a different scene from the [worlds](kinova_gazebo/worlds) folder. The default is ```kinova_tableV1```.
-
-**NOTE:** if Gazebo models need to be installed, Gazebo node may not launch correctly. Gazebo will take some time to load as it is downloading required models, once loaded the arm will probably just fall due to controller timeout. Resolved by relaunching after Gazebo finishes downloading models and loads up.  
-
-### Planner
 ```
 $ roslaunch planner gazebo.launch world:=kinova_tableV2
 ```
 
+**NOTE:** if Gazebo models need to be installed, Gazebo node may not launch correctly. Gazebo will take some time to load as it is downloading required models, once loaded the arm will probably just fall due to controller timeout. Resolved by relaunching after Gazebo finishes downloading models and loads up.  
+
+### Planner
 Finally, run the planner using:
 
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ All third party licenses can be found in their respective folders in this reposi
 ### gazebo_grasp_plugin
 Cloned from [gazebo-pkgs](https://github.com/JenniferBuehler/gazebo-pkgs) repo by [Jennifer Buehler](https://github.com/JenniferBuehler). The master branch was cloned, commit baf0f033475c3a592efb0862079f3ff8392cadf6.  
 
-This package is used as a workaround to limitations in Gazebo for grasping operations (objects tend to slip/get pushed away when a grasp is attempted). Adding very high friction to the Kinova fingers is also a workaround. For this project, both the plugin and custom friction values are used. Another change was done to the Kinova description files regarding the finger tips, this is explained in [here](#Changes-to-Kinova-model)
+This package is used as a workaround to limitations in Gazebo for grasping operations (objects tend to slip/get pushed away when a grasp is attempted). Adding very high friction to the Kinova fingers is also a workaround. For this project, both the plugin and custom friction values are used. Another change was done to the Kinova description files regarding the finger tips, this is explained in the next section
 
 ### Kinova packages
 The [kinova_control](kinova_control/), [kinova_description](kinova_description/), and [kinova_gazebo](kinova_gazebo) packages are from the official [kinova-ros](https://github.com/Kinovarobotics/kinova-ros/tree/master) package by [Kinova Robotics](https://github.com/Kinovarobotics). The master branch was cloned, commit 99ac039028855eb9c1000a9c51b9c1544d5ef446.
@@ -136,6 +136,8 @@ The [kinova_control](kinova_control/), [kinova_description](kinova_description/)
 ## Changes to Jaco2 Models
 ### Finger Tips For All Models
 The Kinova's finger tips in the description files have been changed to be a fixed joint and disabled in the controller configs.
+
+A [file](kinova_description/urdf/kinova_finger_friction.xacro) was made to add custom friction values to both parts of the finger sets as well.
 
 The joints would sporadically move when a grasp is attempted and often resulted in the grasp plugin not working correctly and the object being pushed away regardless of set friction values.
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] use ROS params for planner timeouts, name, IK solve type etc.
 - [x] Write up a complete README
 - [ ] Add media files
-- [ ] Add script to randomise Gazebo environment and execute the planner
+- [x] Add script to randomise Gazebo environment and execute the planner
   - [x] scene randomiser
-  - [ ] node to automate planner execution
+  - [x] node to automate planner execution
 - [ ] Change planner to use online planning

--- a/gazebo_geometries_plugin/README.md
+++ b/gazebo_geometries_plugin/README.md
@@ -5,9 +5,9 @@ This plugin was developed while working on a 3rd Year Project at the University 
 
 If a model is requested, a vector containing geometries for all its collision links is returned. If a collision link is requested, a vector of size 1 is returned with only the geometry for that collision link.
 
-The boxes are either Object Oriented Bounding Boxes (OOBB) or Axis Aligned Bounding Boxes (AABB). OOBBs are obtained for box and cylinder shaped objects and collision links, any other shape is treated as an AABB. It should be noted that the service returns enough information to allow the user compute the AABB for the OOBB as well if needed.
+The boxes are either Object Oriented Bounding Boxes (OOBB) or Axis Aligned Bounding Boxes (AABB). OOBBs are obtained for box and cylinder shaped objects and collision links, any other shape is treated as an AABB. It should be noted that the service returns enough information to allow the user to compute the AABB for the OOBB as well if needed.
 
-To include this plugin in a Gazebo world, you will need to include it in the .world file inside the ```<world>``` tag.
+To include this plugin in a Gazebo world, you will need to include it in the .world file inside the ```<world>``` tag.  
 As an example:
 ```
 <world>
@@ -25,7 +25,7 @@ The package will still work as normal without the need to spawn the arms in Gaze
 
 The plugin publishes the geometries as visualisation markers on the topic ```/geometries_markers```.
 
-There is a parameter, ```/gazebo/static_objs```, that can be set to visualise static objects (shown as red). It is a vector of strings of model names that are regarded as static. All geometries are displayed green unless they are specified as static.
+There is a parameter, ```/gazebo/static_objs```, that can be set to visualise static objects (shown as red). It is a vector of strings of model names that are regarded as static, these are not related to the ```static``` attribute within Gazebo. All geometries are displayed green unless they are specified as static.
 
 Another parameter, ```/gazebo/pub_arm_geom```, can be set to visualise the Kinova collision boxes on the same topic as the other geometries.
 
@@ -45,6 +45,7 @@ Replace ```name``` with the name of an object or collision link in the Gazebo wo
 
 the returned variables are as follows:
 
+- ```bool success``` - false if plugin is unable to find the requested model.
 - ```string message``` - status message, it was added mainly if the service is being used through a command line.
 - ```string[] name``` - the link name that the collision box corresponds to.
 - ```geometry_msgs/Vector3[] min_bounds``` - minimum bounds of the box in X, Y, & Z. This essentially is the AABB minimum coordinates.

--- a/gazebo_scene_randomiser_plugin/README.md
+++ b/gazebo_scene_randomiser_plugin/README.md
@@ -33,3 +33,8 @@ To get the name from Gazebo, select the model then in the left side panel, expan
 As an example, the image below shows the required z-axis orientation and objects placed on the "low_shelf" collision link.
 
 ![Gazebo Example](images/example.png)
+
+## Demo
+A demo is shown below of how the plugin works.
+
+![Randomiser Demo](images/randomiser.gif)

--- a/gazebo_scene_randomiser_plugin/README.md
+++ b/gazebo_scene_randomiser_plugin/README.md
@@ -1,16 +1,16 @@
 # Gazebo Scene Randomiser Plugin
-A plugin to randomise objects in the world on a given surface. Objects that are labelled static by Gazebo are unaffected.
+A plugin to randomise objects in the world on a given surface. Objects that have the ```static``` attribute enabled in Gazebo are unaffected, you can determine this by selecting a model and checking the left-side panel for the ```static``` attribute.
 
 This plugin was developed while working on a 3rd Year Project at the University of Leeds for manipulation planning in cluttered environments.
 
-Users interface with the plugin is through a ROS service. The plugin takes in the name of a collision link (the surface) and randomises all the pose of all the 
+User's interface with the plugin is through a ROS service. The plugin takes in the name of a collision link (the surface) and randomises the pose of all the 
 objects in the world on that surface. For position, the x and y values are changed, and for rotation, the z-axis rotation (yaw) is changed.
 
 **IMPORTANT:** Make the surface has its z-axis aligned with the world z-axis and has the same direction. The surface yaw can be changed, but roll and pitch must be zero.
 
 The robot name must be set as a parameter on ```/robot_name``` so that the plugin can avoid changing the robot pose.
 
-To include this plugin in a Gazebo world, you will need to include it in the .world file inside the ```<world>``` tag.
+To include this plugin in a Gazebo world, you will need to include it in the .world file inside the ```<world>``` tag.  
 As an example:
 ```
 <world>

--- a/gazebo_scene_randomiser_plugin/include/gazebo_scene_randomiser_plugin/scene_randomiser_plugin.h
+++ b/gazebo_scene_randomiser_plugin/include/gazebo_scene_randomiser_plugin/scene_randomiser_plugin.h
@@ -24,7 +24,7 @@ namespace gazebo
 
     private:
         void queueThread();
-        bool checkCollision(ignition::math::v4::Pose3d& pose, physics::ModelPtr model, physics::ModelPtr surface);
+        bool checkCollision(ignition::math::v4::Pose3d& pose, physics::ModelPtr model, physics::ModelPtr parent);
         ignition::math::v4::Pose3d getModelPose(const ignition::math::v4::Pose3d& centre, physics::ShapePtr shape);
         bool randomiseSrvCallback(gazebo_scene_randomiser_plugin::randomiseRequest& req, gazebo_scene_randomiser_plugin::randomiseResponse& res);
 

--- a/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
+++ b/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
@@ -159,7 +159,7 @@ bool SceneRandomiser::randomiseSrvCallback(gazebo_scene_randomiser_plugin::rando
         res.message = "Surface shape not supported";
         res.success = false;
         ROS_ERROR("[SceneRandomiser]: Unsupported surface shape!");   
-        return false;
+        return true;
     }
 
     std::vector<physics::ModelPtr> models = world_->Models();

--- a/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
+++ b/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
@@ -30,7 +30,7 @@ void SceneRandomiser::Load(physics::WorldPtr _world, sdf::ElementPtr _sdf)
     ROS_INFO("%sSceneRandomiser: Plugin loaded!", GREEN);
 }
 
-bool SceneRandomiser::checkCollision(ignition::math::v4::Pose3d& pose, physics::ModelPtr model, physics::ModelPtr surface)
+bool SceneRandomiser::checkCollision(ignition::math::v4::Pose3d& pose, physics::ModelPtr model, physics::ModelPtr parent)
 {
     std::vector<physics::ModelPtr> models = world_->Models();
 
@@ -51,7 +51,7 @@ bool SceneRandomiser::checkCollision(ignition::math::v4::Pose3d& pose, physics::
     for (int i = 0; i < models.size(); i++)
     {
         if (models[i] == model ||
-            models[i] == surface ||
+            models[i] == parent ||
             models[i]->GetName() == "ground_plane" ||
             models[i]->GetName() == "sun" ||
             models[i]->GetName() == robot_name_)

--- a/planner/CMakeLists.txt
+++ b/planner/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   trac_ik_lib
   gazebo_geometries_plugin
+  gazebo_scene_randomiser_plugin
 )
 
 find_package(gazebo REQUIRED)
@@ -64,7 +65,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES planner
- CATKIN_DEPENDS roscpp trajectory_msgs control_msgs actionlib_msgs trac_ik_lib gazebo_geometries_plugin
+ CATKIN_DEPENDS roscpp trajectory_msgs control_msgs actionlib_msgs trac_ik_lib gazebo_geometries_plugin gazebo_scene_randomiser_plugin
 #  DEPENDS system_lib
 )
 
@@ -90,4 +91,11 @@ target_link_libraries(planner_node
   ${GAZEBO_LIBRARIES}
   fcl
   Eigen3::Eigen
+)
+
+add_executable(tester test/tester.cpp)
+add_dependencies(tester ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(tester
+  ${catkin_LIBRARIES}
+  ${GAZEBO_LIBRARIES}
 )

--- a/planner/include/planner/controller.h
+++ b/planner/include/planner/controller.h
@@ -9,7 +9,6 @@
 #include <gazebo_geometries_plugin/geometry.h>
 
 #include "util.h"
-#include "planner.h"
 #include "manipulator.h"
 
 typedef actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> ArmActionSimple;
@@ -18,7 +17,7 @@ typedef boost::shared_ptr<ArmActionSimple> ArmControlPtr;
 class Controller
 {
 public:
-    Controller(ros::NodeHandle* nh);
+    Controller(ros::NodeHandle* nh, Manipulator* manip);
     ~Controller();
 
     void run();
@@ -30,31 +29,21 @@ public:
     
 private:
     void init();
-    void getCollisionBoxes();
-    void statesCallback(gazebo_msgs::ModelStatesConstPtr msg);
-    bool startPlanSrvCallback(planner::start_plan::Request& req, planner::start_plan::Response& res);
     bool homeSrvCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
     bool initSrvCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
     bool openGripperSrvCallback(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
     bool closeGripperSrvCallback(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
 
-    Manipulator manipulator_;
-    Planner planner_;
+    Manipulator* manipulator_;
 
     ArmControlPtr armAction_;
     ArmControlPtr gripperAction_;
 
     ros::NodeHandle nh_;
-    ros::Subscriber states_sub_;
-    ros::ServiceServer start_plan_srv;
     ros::ServiceServer home_srv_;
     ros::ServiceServer init_srv_;
     ros::ServiceServer open_gripper_srv_;
     ros::ServiceServer close_gripper_srv_;
-    ros::ServiceClient collisions_client_;
-
-    gazebo_msgs::ModelStates states_;
-    std::vector<util::CollisionGeometry> collision_geometries_;
     
     bool gripper_open_;
 };

--- a/planner/include/planner/manipulator.h
+++ b/planner/include/planner/manipulator.h
@@ -39,8 +39,6 @@ private:
     void setJointsInfo();
     void initSolvers();
     void setDefaultPoses();
-    void setUpperBounds();
-    void setLowerBounds();
     void setDHParameters();
     void setDHTheta();
     void jointStatesCallback(sensor_msgs::JointStateConstPtr msg);

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -30,7 +30,7 @@ namespace og = ompl::geometric;
 class Planner
 {
 public:
-    Planner(ros::NodeHandle* nh, Manipulator* manip);
+    Planner(ros::NodeHandle* nh);
     ~Planner();
 
     bool plan();

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -22,6 +22,7 @@
 #include "util.h"
 #include "defines.h"
 #include "manipulator.h"
+#include "controller.h"
 
 namespace ob = ompl::base;
 namespace og = ompl::geometric;
@@ -32,7 +33,7 @@ public:
     Planner(ros::NodeHandle* nh, Manipulator* manip);
     ~Planner();
 
-    bool plan(trajectory_msgs::JointTrajectory& traj);
+    bool plan();
     void setStart(const Eigen::Vector3d& start, const Eigen::Quaterniond& orientation);
     void setGoal(const Eigen::Vector3d& goal, const Eigen::Quaterniond& orientation);
     void setCollisionGeometries(const std::vector<util::CollisionGeometry>& collision_boxes);
@@ -46,13 +47,19 @@ private:
     bool generateTrajectory(trajectory_msgs::JointTrajectory& traj);
     void publishGoalMarker();
     void publishMarkers();
+    void modelStatesCallback(const gazebo_msgs::ModelStatesConstPtr msg);
+    void update();
     bool isObjectBlocked(std::vector<int>& idxs);
     void planInClutter(std::vector<int> idxs, std::vector<ob::ScopedState<ob::SE3StateSpace>>& states);
     bool getPushAction(std::vector<ob::ScopedState<ob::SE3StateSpace>>& states, std::vector<util::CollisionGeometry>& objs,
         const util::CollisionGeometry& geom);
+    bool startPlanSrvCallback(planner::start_plan::Request& req, planner::start_plan::Response& res);
 
     ros::NodeHandle nh_;
     ros::Publisher marker_pub_;
+    ros::Subscriber models_sub_;
+    ros::ServiceServer start_plan_srv_;
+    ros::ServiceClient collisions_client_;
 
     bool save_path_;
     bool display_path_;
@@ -60,10 +67,12 @@ private:
     int path_states_;
     std::string planner_name_;
 
-    Manipulator* manipulator_;
+    Manipulator manipulator_;
+    Controller controller_;
 
     double plan_time_;
     util::CollisionGeometry target_geom_;
+    gazebo_msgs::ModelStatesConstPtr models_;
 
     std::vector<std::string> static_objs_;
     std::vector<util::CollisionGeometry> collision_boxes_;

--- a/planner/launch/tester.launch
+++ b/planner/launch/tester.launch
@@ -1,0 +1,10 @@
+<launch>
+
+    <arg name="num_runs"    default="10" />
+    <arg name="surface"   default="short_table_link_surface" />
+
+    <node name="planner_tester_node" pkg="planner" type="tester" output="screen" >
+        <param name="num_runs"      value="$(arg num_runs)" />
+        <param name="surface"       value="$(arg surface)" />
+    </node>
+</launch>

--- a/planner/package.xml
+++ b/planner/package.xml
@@ -21,6 +21,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>trac_ik_lib</build_depend>
   <build_depend>gazebo_geometries_plugin</build_depend>
+  <build_depend>gazebo_scene_randomiser_plugin</build_depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>trajectory_msgs</build_export_depend>
@@ -35,6 +36,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>trac_ik_lib</exec_depend>
   <exec_depend>gazebo_geometries_plugin</exec_depend>
+  <exec_depend>gazebo_scene_randomiser_plugin</exec_depend>
   <exec_depend>message_runtime</exec_depend>
 
 

--- a/planner/paths/plot.sh
+++ b/planner/paths/plot.sh
@@ -17,7 +17,7 @@ if [ -z "$*" ]; then
     exit 0
 fi
 
-while getopts ":f:h:" opt; do
+while getopts ":f:h" opt; do
     case "${opt}" in
         f)
             filename=$OPTARG

--- a/planner/src/controller.cpp
+++ b/planner/src/controller.cpp
@@ -1,7 +1,7 @@
 #include "planner/controller.h"
 
-Controller::Controller(ros::NodeHandle* nh)
-    : nh_(*nh), manipulator_(nh), planner_(nh, &manipulator_)
+Controller::Controller(ros::NodeHandle* nh, Manipulator* manip)
+    : nh_(*nh), manipulator_(manip)
 {
     this->init();
     gripper_open_ = false;
@@ -37,7 +37,7 @@ void Controller::openGripper()
     msg.joint_names.resize(3);
     msg.points.resize(1);
 
-    msg.joint_names = manipulator_.getFingerNames();
+    msg.joint_names = manipulator_->getFingerNames();
     msg.points[0].positions.resize(3);
     msg.points[0].positions = {0.4, 0.4, 0.4};
     msg.points[0].time_from_start = ros::Duration(2);
@@ -64,7 +64,7 @@ void Controller::closeGripper()
     msg.joint_names.resize(3);
     msg.points.resize(1);
 
-    msg.joint_names = manipulator_.getFingerNames();
+    msg.joint_names = manipulator_->getFingerNames();
     msg.points[0].positions.resize(3);
     msg.points[0].positions = {0.95, 0.95, 0.95};
     msg.points[0].time_from_start = ros::Duration(2);
@@ -81,10 +81,10 @@ void Controller::closeGripper()
 
 void Controller::goToHome()
 {
-    std::vector<double> current_pos = manipulator_.getJointStates().position;
-    for (int i = 0; i < manipulator_.getFingerNames().size(); i++) current_pos.pop_back();
+    std::vector<double> current_pos = manipulator_->getJointStates().position;
+    for (int i = 0; i < manipulator_->getFingerNames().size(); i++) current_pos.pop_back();
 
-    if (util::approxEqual(current_pos, manipulator_.getHomePose(), 1e-2))
+    if (util::approxEqual(current_pos, manipulator_->getHomePose(), 1e-2))
     {
         ROS_INFO("%s[CONTROLLER]: Kinova is already at home pose!", GREEN);
         return;
@@ -96,11 +96,11 @@ void Controller::goToHome()
 
     // joints
     joints_msg.points.resize(1);
-    joints_msg.joint_names.resize(manipulator_.getNumJoints());
-    joints_msg.points[0].positions.resize(manipulator_.getNumJoints());
+    joints_msg.joint_names.resize(manipulator_->getNumJoints());
+    joints_msg.points[0].positions.resize(manipulator_->getNumJoints());
 
-    joints_msg.joint_names = manipulator_.getJointNames();
-    joints_msg.points[0].positions = manipulator_.getHomePose();
+    joints_msg.joint_names = manipulator_->getJointNames();
+    joints_msg.points[0].positions = manipulator_->getHomePose();
     joints_msg.points[0].time_from_start = ros::Duration(10);
 
     joints_msg.header.stamp = ros::Time::now();
@@ -111,10 +111,10 @@ void Controller::goToHome()
 
 void Controller::goToInit()
 {
-    std::vector<double> current_pos = manipulator_.getJointStates().position;
-    for (int i = 0; i < manipulator_.getFingerNames().size(); i++) current_pos.pop_back();
+    std::vector<double> current_pos = manipulator_->getJointStates().position;
+    for (int i = 0; i < manipulator_->getFingerNames().size(); i++) current_pos.pop_back();
     
-    if (util::approxEqual(current_pos, manipulator_.getInitPose(), 1e-2))
+    if (util::approxEqual(current_pos, manipulator_->getInitPose(), 1e-2))
     {
         ROS_INFO("%s[CONTROLLER]: Kinova is already at init pose!", GREEN);
         return;
@@ -126,11 +126,11 @@ void Controller::goToInit()
 
     // joints
     joints_msg.points.resize(1); 
-    joints_msg.joint_names.resize(manipulator_.getNumJoints());
-    joints_msg.points[0].positions.resize(manipulator_.getNumJoints());
+    joints_msg.joint_names.resize(manipulator_->getNumJoints());
+    joints_msg.points[0].positions.resize(manipulator_->getNumJoints());
 
-    joints_msg.joint_names = manipulator_.getJointNames();    
-    joints_msg.points[0].positions = manipulator_.getInitPose();
+    joints_msg.joint_names = manipulator_->getJointNames();    
+    joints_msg.points[0].positions = manipulator_->getInitPose();
     joints_msg.points[0].time_from_start = ros::Duration(10);
 
     joints_msg.header.stamp = ros::Time::now();
@@ -142,152 +142,16 @@ void Controller::goToInit()
 
 void Controller::init()
 {
-    states_sub_ = nh_.subscribe("/gazebo/model_states", 10, &Controller::statesCallback, this);
-    start_plan_srv = nh_.advertiseService("start_plan", &Controller::startPlanSrvCallback, this);
     home_srv_ = nh_.advertiseService("go_to_home", &Controller::homeSrvCallback, this);
     init_srv_ = nh_.advertiseService("go_to_init", &Controller::initSrvCallback, this);
     open_gripper_srv_ = nh_.advertiseService("open_gripper", &Controller::openGripperSrvCallback, this);
     close_gripper_srv_ = nh_.advertiseService("close_gripper", &Controller::closeGripperSrvCallback, this);
-    collisions_client_ = nh_.serviceClient<gazebo_geometries_plugin::geometry>("/gazebo/get_geometry");
 
-    while (states_sub_.getNumPublishers() == 0 && ros::ok())
-    {
-        ROS_INFO_THROTTLE(5, "%s[CONTROLLER]: Waiting for Gazebo topics to come up...", CYAN);
-    }
-    armAction_.reset(new ArmActionSimple(manipulator_.getName() + "/effort_joint_trajectory_controller/follow_joint_trajectory"));
-    gripperAction_.reset(new ArmActionSimple(manipulator_.getName() + "/effort_finger_trajectory_controller/follow_joint_trajectory"));
+    armAction_.reset(new ArmActionSimple(manipulator_->getName() + "/effort_joint_trajectory_controller/follow_joint_trajectory"));
+    gripperAction_.reset(new ArmActionSimple(manipulator_->getName() + "/effort_finger_trajectory_controller/follow_joint_trajectory"));
 
     armAction_->waitForServer();
     ROS_INFO("%s[CONTROLLER]: All topics and servers up!", GREEN);
-}
-
-void Controller::getCollisionBoxes()
-{
-    collision_geometries_.clear();
-
-    for (size_t i = 0; i < states_.name.size(); i++)
-    {
-        if (states_.name[i].find(manipulator_.getName()) != std::string::npos) continue;
-
-        gazebo_geometries_plugin::geometry srv;
-        srv.request.model_name = states_.name[i];
-        if (collisions_client_.call(srv))
-        {
-            for (size_t j = 0; j < srv.response.name.size(); j++)
-            {
-                util::CollisionGeometry temp;
-                temp.name = srv.response.name[j];
-                temp.pose = srv.response.pose[j];
-                temp.min = srv.response.min_bounds[j];
-                temp.max = srv.response.max_bounds[j];
-                temp.dimension = srv.response.dimensions[j];
-                // std::cout << srv.response.dimensions[j].x << " -- " << srv.response.name[j] << " -- " << states_.name[i] << std::endl;
-                collision_geometries_.push_back(temp);
-            }
-        }
-    }
-
-    int num_joints = manipulator_.getNumJoints();
-    //  collision geometries for Kinova links and fingers
-    for (int i = 0 ; i < num_joints+3; i++)
-    {
-        std::string link;
-        if (i < manipulator_.getNumJoints()) { link = "_link_" + std::to_string(i+1); }
-        else { link = "_link_finger_" + std::to_string((i+1)-num_joints); }
-
-        gazebo_geometries_plugin::geometry srv;
-        srv.request.model_name = manipulator_.getName() + link;
-        if (collisions_client_.call(srv))
-        {
-            for (size_t j = 0; j < srv.response.name.size(); j++)
-            {
-                util::CollisionGeometry temp;
-                temp.name = srv.response.name[j];
-                temp.pose = srv.response.pose[j];
-                temp.min = srv.response.min_bounds[j];
-                temp.max = srv.response.max_bounds[j];
-                temp.dimension = srv.response.dimensions[j];
-                collision_geometries_.push_back(temp);
-            }
-        }
-    }
-
-    // reset saved states to force recheck of world models
-    states_ = gazebo_msgs::ModelStates();
-}
-
-void Controller::statesCallback(gazebo_msgs::ModelStatesConstPtr msg)
-{
-    states_ = *msg;
-}
-
-bool Controller::startPlanSrvCallback(planner::start_plan::Request& req, planner::start_plan::Response& res)
-{
-    this->goToInit();
-
-    ROS_INFO("%s[CONTROLLER]: Recieved request for %s!", CYAN, req.target.c_str());
-    if (states_.name.empty())
-    {
-        ROS_ERROR("[CONTROLLER]: No states received from Gazebo!");
-        res.message = "Unable to start, No states received from Gazebo!";
-        return true;
-    }
-
-    if (req.target.find("_collision") == std::string::npos) req.target += "_collision";
-
-    this->openGripper();
-    this->getCollisionBoxes();
-    Eigen::Vector3d goal;
-    bool found_target = false;
-    for (int i = 0; i < collision_geometries_.size(); i++)
-    {
-        if (collision_geometries_[i].name.compare(req.target) == 0)
-        {
-            planner_.setTargetGeometry(collision_geometries_[i]);
-            goal << collision_geometries_[i].pose.position.x,
-                    collision_geometries_[i].pose.position.y,
-                    collision_geometries_[i].pose.position.z;
-            found_target = true;
-            break;
-        }
-    }
-
-    if (!found_target)
-    {
-        ROS_ERROR("[CONTROLLER]: Unable to find collision geometry for [%s]", req.target.c_str());
-        res.message = "Unable to start, target not found!";
-        return true;
-    }
-    else if (sqrt((goal[0]*goal[0]) + (goal[1]*goal[1]) + (goal[2]*goal[2])) > 0.95)
-    {
-        ROS_ERROR("[CONTROLLER]: Target is out of reach!");
-        res.message = "Unable to start, target is out of reach!";
-        return true;
-    }
-
-    std::vector<Eigen::Vector3d> start_positions; std::vector<Eigen::Quaterniond> start_orientations;
-    manipulator_.solveFK(start_positions, start_orientations);
-    
-    planner_.clearMarkers();
-    planner_.setCollisionGeometries(collision_geometries_);
-    planner_.setStart(start_positions.back(), start_orientations.back());
-    planner_.setGoal(goal, start_orientations.back());
-
-    trajectory_msgs::JointTrajectory traj;
-    if (planner_.plan(traj))
-    {
-        this->sendAction(traj);
-        this->closeGripper();
-        
-        // pause for 1 second to allow time for grasp plugin to attach object
-        ros::Duration(1).sleep();
-    }
-    else
-    {
-        ROS_ERROR("[CONTROLLER]: Planner unable to find solution");
-        res.message = "Unable to find solution!";
-    }
-    return true;
 }
 
 bool Controller::homeSrvCallback(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res)

--- a/planner/src/node.cpp
+++ b/planner/src/node.cpp
@@ -16,9 +16,11 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "planner_node");
     ros::NodeHandle nh;
     
-    while (!checkGazeboIsUp() && ros::ok())
+    while (!checkGazeboIsUp())
     {
         ROS_WARN_THROTTLE(5, "Gazebo not detected! Waiting...");
+
+        if (!ros::ok()) { return EXIT_SUCCESS;} 
     }
 
     ROS_INFO("%sGazebo is up! Starting...", GREEN);

--- a/planner/src/node.cpp
+++ b/planner/src/node.cpp
@@ -1,4 +1,3 @@
-#include "planner/controller.h"
 #include "planner/planner.h"
 
 bool checkGazeboIsUp()
@@ -23,8 +22,8 @@ int main(int argc, char** argv)
     }
 
     ROS_INFO("%sGazebo is up! Starting...", GREEN);
-    
-    Controller controller(&nh);
+
+    Planner planner(&nh);
     ros::MultiThreadedSpinner spinner(3);
     spinner.spin();
 

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -1,7 +1,7 @@
 #include "planner/planner.h"
 
-Planner::Planner(ros::NodeHandle* nh, Manipulator* manip)
-    : nh_(*nh), manipulator_(manip)
+Planner::Planner(ros::NodeHandle* nh)
+    : nh_(*nh), manipulator_(nh), controller_(nh, &manipulator_)
 {
     this->initROS();
     this->init();
@@ -12,7 +12,7 @@ Planner::~Planner()
 
 }
 
-bool Planner::plan(trajectory_msgs::JointTrajectory& traj)
+bool Planner::plan()
 {
     state_checker_->setTargetCollision(true);
     state_checker_->setNonStaticCollisions(false);
@@ -30,6 +30,7 @@ bool Planner::plan(trajectory_msgs::JointTrajectory& traj)
     if (solved != ob::PlannerStatus::EXACT_SOLUTION)
     {
         std::cout << RED << "[PLANNER]: No solution found!" << NC << std::endl;
+        plan_time_ = chrono::duration_cast<chrono::milliseconds>(t_end-t_start).count()/1000.0;
         return false;
     }
 
@@ -100,11 +101,11 @@ bool Planner::plan(trajectory_msgs::JointTrajectory& traj)
 
     int64_t duration = chrono::duration_cast<chrono::milliseconds>(t_end-t_start).count();
     std::cout << CYAN << "Planner took: " << duration << " ms (" << duration/1000.0 << " sec)" << std::endl;
-    plan_time_ = duration;
+    plan_time_ = duration/1000.0;
 
     if (save_path_ || display_path_) { this->savePath(); }
 
-    return this->generateTrajectory(traj);
+    return true;
 }
 
 void Planner::setStart(const Eigen::Vector3d& start, const Eigen::Quaterniond& orientation)
@@ -228,7 +229,7 @@ void Planner::savePath()
 void Planner::clearMarkers()
 {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = manipulator_->getName() + "_link_base";
+    marker.header.frame_id = manipulator_.getName() + "_link_base";
 	marker.action = visualization_msgs::Marker::DELETEALL;
     marker_pub_.publish(marker);
 }
@@ -246,7 +247,7 @@ void Planner::init()
     
     // space information and validity checker
     si_ = ob::SpaceInformationPtr(new ob::SpaceInformation(space_));
-    state_checker_ = std::make_shared<StateChecker>(StateChecker(si_, manipulator_, &collision_boxes_));
+    state_checker_ = std::make_shared<StateChecker>(StateChecker(si_, &manipulator_, &collision_boxes_));
     si_->setStateValidityChecker(ob::StateValidityCheckerPtr(state_checker_));
     si_->setStateValidityCheckingResolution(0.001);
     si_->setup();
@@ -257,12 +258,17 @@ void Planner::init()
 
     if (planner_name_ == "RRTStar") { planner_ = ob::PlannerPtr(new og::RRTstar(si_)); }
     else if (planner_name_ == "BFMT") { planner_ = ob::PlannerPtr(new og::BFMT(si_)); }
-    else { planner_ = ob::PlannerPtr(new og::KPIECE1(si_)); planner_->setup(); }    
+    else { planner_ = ob::PlannerPtr(new og::KPIECE1(si_)); planner_->setup(); }
+
+    ROS_INFO("%s[PLANNER]: Initialised!", GREEN);
 }
 
 void Planner::initROS()
 {
     marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/visualization_marker", 10);
+    models_sub_ = nh_.subscribe("/gazebo/model_states", 10, &Planner::modelStatesCallback, this);
+    start_plan_srv_ = nh_.advertiseService("/start_plan", &Planner::startPlanSrvCallback, this);
+    collisions_client_ = nh_.serviceClient<gazebo_geometries_plugin::geometry>("/gazebo/get_geometry", 10);
 
     ros::param::param<std::vector<std::string>>("/gazebo/static_objects", static_objs_, {"INVALID"});
     ros::param::param<std::string>("~planner/name", planner_name_, "KPIECE1");
@@ -290,6 +296,11 @@ void Planner::initROS()
     ROS_INFO_STREAM(BLUE << "display_path\t: " << std::boolalpha << display_path_);
     
     ROS_INFO("%s*****************************", BLUE);
+
+    while (models_sub_.getNumPublishers() == 0 && ros::ok())
+    {
+        ROS_INFO_DELAYED_THROTTLE(5, "%s[PLANNER]: Waiting for Gazebo topics to come up...", CYAN);
+    }
 }
 
 bool Planner::generateTrajectory(trajectory_msgs::JointTrajectory& traj)
@@ -305,11 +316,11 @@ bool Planner::generateTrajectory(trajectory_msgs::JointTrajectory& traj)
         path_states.insert(path_states.end(), solution_states.begin(), solution_states.end());
     }
 
-    int num_joints = manipulator_->getNumJoints();
+    int num_joints = manipulator_.getNumJoints();
 
     traj.joint_names.resize(num_joints);
     traj.points.resize(path_states.size());
-    traj.joint_names = manipulator_->getJointNames();
+    traj.joint_names = manipulator_.getJointNames();
 
     for (size_t i = 0; i < path_states.size(); i++)
     {
@@ -330,8 +341,8 @@ bool Planner::generateTrajectory(trajectory_msgs::JointTrajectory& traj)
 
         std::vector<double> angles;
         bool success = false;
-        if (i == 0) { success = manipulator_->solveIK(angles, position, orientation, manipulator_->getInitPose()); }
-        else { success = manipulator_->solveIK(angles, position, orientation, traj.points[i-1].positions); }
+        if (i == 0) { success = manipulator_.solveIK(angles, position, orientation, manipulator_.getInitPose()); }
+        else { success = manipulator_.solveIK(angles, position, orientation, traj.points[i-1].positions); }
 
         if (success) { traj.points[i].positions = angles; }
         else
@@ -361,7 +372,7 @@ void Planner::publishGoalMarker()
     marker.color.b = marker.color.a = 1.0;
     marker.color.r = marker.color.g = 0.0;
     marker.ns = "goal";
-    marker.header.frame_id = manipulator_->getName() + "_link_base";
+    marker.header.frame_id = manipulator_.getName() + "_link_base";
     marker.header.stamp = ros::Time::now();
     marker.action = visualization_msgs::Marker::ADD;
     marker.type = visualization_msgs::Marker::CUBE;
@@ -381,7 +392,7 @@ void Planner::publishMarkers()
         // ---> state markers
         marker.id = j;
         marker.ns = "states";
-        marker.header.frame_id = manipulator_->getName() + "_link_base";
+        marker.header.frame_id = manipulator_.getName() + "_link_base";
         marker.header.stamp = ros::Time::now();
         marker.color.a = 1.0; marker.color.g = 1.0; marker.color.r = marker.color.g = 0;
         marker.type = visualization_msgs::Marker::SPHERE;
@@ -413,7 +424,7 @@ void Planner::publishMarkers()
             marker.color.a = 1.0;
 
             marker.ns = "path";
-            marker.header.frame_id = manipulator_->getName() + "_link_base";
+            marker.header.frame_id = manipulator_.getName() + "_link_base";
             marker.header.stamp = ros::Time::now();
 
             geometry_msgs::Point p;
@@ -443,6 +454,80 @@ void Planner::publishMarkers()
     }
 }
 
+void Planner::modelStatesCallback(gazebo_msgs::ModelStatesConstPtr msg)
+{
+    models_ = msg;
+}
+
+void Planner::update()
+{
+    collision_boxes_.clear();
+
+    for (size_t i = 0; i < models_->name.size(); i++)
+    {
+        if (models_->name[i].find(manipulator_.getName()) != std::string::npos) continue;
+
+        gazebo_geometries_plugin::geometry srv;
+        srv.request.model_name = models_->name[i];
+        if (collisions_client_.call(srv))
+        {
+            if (!srv.response.success)
+            {
+                ROS_ERROR("[PLANNER]: Geometries plugin returned an error for [%s]!", models_->name[i].c_str());
+                continue;
+            }
+
+            for (size_t j = 0; j < srv.response.name.size(); j++)
+            {
+                util::CollisionGeometry temp;
+                temp.name = srv.response.name[j];
+                temp.pose = srv.response.pose[j];
+                temp.min = srv.response.min_bounds[j];
+                temp.max = srv.response.max_bounds[j];
+                temp.dimension = srv.response.dimensions[j];
+                
+                collision_boxes_.push_back(temp);
+
+                if (temp.name == target_geom_.name)
+                {
+                    this->setTargetGeometry(temp);
+                }
+            }
+        }
+    }
+
+    int num_joints = manipulator_.getNumJoints();
+    // collision geometries for Kinova links and fingers
+    for (int i = 0 ; i < num_joints+3; i++)
+    {
+        std::string link;
+        if (i < manipulator_.getNumJoints()) { link = "_link_" + std::to_string(i+1); }
+        else { link = "_link_finger_" + std::to_string((i+1)-num_joints); }
+
+        gazebo_geometries_plugin::geometry srv;
+        srv.request.model_name = manipulator_.getName() + link;
+        if (collisions_client_.call(srv))
+        {
+            if (!srv.response.success)
+            {
+                ROS_ERROR("[PLANNER]: Geometries plugin returned an error for [%s]!", srv.request.model_name.c_str());
+                continue;
+            }
+
+            for (size_t j = 0; j < srv.response.name.size(); j++)
+            {
+                util::CollisionGeometry temp;
+                temp.name = srv.response.name[j];
+                temp.pose = srv.response.pose[j];
+                temp.min = srv.response.min_bounds[j];
+                temp.max = srv.response.max_bounds[j];
+                temp.dimension = srv.response.dimensions[j];
+                collision_boxes_.push_back(temp);
+            }
+        }
+    }
+}
+
 bool Planner::isObjectBlocked(std::vector<int>& idxs)
 {
     bool clear = true;
@@ -457,7 +542,7 @@ bool Planner::isObjectBlocked(std::vector<int>& idxs)
             std::abs(collision_boxes_[i].pose.position.z - goal_pos_.z()) > 0.2;
         
         if (is_static || out_of_workspace ||
-            collision_boxes_[i].name.find(manipulator_->getName()) != std::string::npos ||
+            collision_boxes_[i].name.find(manipulator_.getName()) != std::string::npos ||
             collision_boxes_[i].name.find(target_geom_.name) != std::string::npos)
         { continue; }
 
@@ -507,7 +592,7 @@ void Planner::planInClutter(std::vector<int> idxs, std::vector<ob::ScopedState<o
             for (int j = 0; j < objects.size(); j++)
             {
                 if (orig.name == objects[j].name || objects[j].name.find("_merged") != std::string::npos) continue;
-          
+
                 bool intersect = (orig.min.x < objects[j].max.x) && (orig.max.x > objects[j].min.x);
 
                 if (intersect)
@@ -641,6 +726,66 @@ bool Planner::getPushAction(std::vector<ob::ScopedState<ob::SE3StateSpace>>& sta
     push_state->setX(geom.pose.position.x + (direction*0.1));
     push_state->setY(goal_pos_.y());
     states.push_back(push_state);
+
+    return true;
+}
+
+bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::start_plan::Response& res)
+{
+    if (req.target.find("_collision") == std::string::npos) req.target += "_collision";
+
+    target_geom_.name = req.target;
+    target_geom_.dimension.x = target_geom_.dimension.y = target_geom_.dimension.z = -1;
+    this->update();
+
+    Eigen::Vector3d goal_xyz = Eigen::Vector3d(target_geom_.pose.position.x,
+                                            target_geom_.pose.position.y,
+                                            target_geom_.pose.position.z);
+
+    if (target_geom_.dimension.x == -1)
+    {
+        ROS_ERROR("[PLANNER]: Unable to find collision geometry for [%s]", req.target.c_str());
+        res.message = "Unable to start, target not found!";
+        return true;
+    }
+    else if (std::sqrt((goal_xyz[0]*goal_xyz[0]) + (goal_xyz[1]*goal_xyz[1]) + (goal_xyz[2]*goal_xyz[2])) > 0.95)
+    {
+        ROS_ERROR("[PLANNER]: Target is out of reach!");
+        res.message = "Unable to start, target is out of reach!";
+        return true;
+    }
+
+    controller_.goToInit();
+    controller_.openGripper();
+
+    std::vector<Eigen::Vector3d> start_positions; std::vector<Eigen::Quaterniond> start_orientations;
+    manipulator_.solveFK(start_positions, start_orientations);
+
+    this->clearMarkers();
+    this->setStart(start_positions.back(), start_orientations.back());
+    this->setGoal(goal_xyz, start_orientations.back());
+
+    bool success = this->plan();
+
+    if (success)
+    {
+        trajectory_msgs::JointTrajectory traj;
+
+        if (!this->generateTrajectory(traj))
+        {
+            ROS_ERROR("[PLANNER]: Solution path found but is not kinematically valid!");
+            res.message = "Solution path found but is not kinematically valid!";
+            return true;
+        }
+
+        controller_.sendAction(traj);
+        controller_.closeGripper();
+    }
+    else
+    {
+        ROS_ERROR("[PLANNER]: unable to find solution");
+        res.message = "Unable to find solution!";
+    }
 
     return true;
 }

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -290,7 +290,7 @@ void Planner::initROS()
     for (int i = 0; i < static_objs_.size(); i++) { ss << static_objs_[i] << " "; }
     ROS_INFO_STREAM(BLUE << "Static Objs\t: " << ss.str());
     ROS_INFO_STREAM(BLUE << "name\t\t: " << planner_name_);
-    ROS_INFO_STREAM(BLUE << "timeout\t\t: " << timeout_);
+    ROS_INFO_STREAM(BLUE << "timeout\t: " << timeout_);
     ROS_INFO_STREAM(BLUE << "path_states\t: " << path_states_);
     ROS_INFO_STREAM(BLUE << "save_path\t: " << std::boolalpha << save_path_);
     ROS_INFO_STREAM(BLUE << "display_path\t: " << std::boolalpha << display_path_);

--- a/planner/srv/start_plan.srv
+++ b/planner/srv/start_plan.srv
@@ -1,3 +1,7 @@
 string target
 ---
 string message
+bool path_found
+bool path_valid
+bool grasp_success
+float64 plan_time

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -118,7 +118,7 @@ private:
         if (planning_client_.call(plan_req))
         {
             std::fstream file;
-            file.open(log_file_, std::fstream::out);
+            file.open(log_file_, std::fstream::app);
             
             // annoyingly, bool variables in ROS srv/msg are represented as uint8, so each one needs to
             // be cast to bool type to print them out correctly

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -4,9 +4,10 @@
 #include <gazebo_scene_randomiser_plugin/randomise.h>
 #include <gazebo_msgs/ModelStates.h>
 #include <gazebo_msgs/SetModelState.h>
+#include <ros/ros.h>
 #include <ros/package.h>
+#include <std_srvs/Empty.h>
 #include <boost/filesystem.hpp>
-#include "planner/util.h"
 #include "planner/defines.h"
 
 class Tester
@@ -77,7 +78,7 @@ private:
         {
             if (!boost::filesystem::create_directories(ss.str()))
             {
-                ROS_FATAL("Failed to create log directory!");
+                ROS_FATAL("[TESTER]: Failed to create log directory!");
                 ros::shutdown();
                 exit(-1);
             }
@@ -109,7 +110,7 @@ private:
         randomise_req.request.surface = surface_;
         if (!randomiser_client_.call(randomise_req))
         {
-            ROS_FATAL("Error calling randomiser service!");
+            ROS_FATAL("[TESTER]: Error calling randomiser service!");
             ros::shutdown();
             exit(-1);
         }

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -31,11 +31,8 @@ public:
         {
             ROS_INFO("[TESTER]: Starting run #%d ...", i);
 
-            if (this->runPlannerAndLog())
-            {
-                // only reset if arm has actually moved to execute a plan
-                this->resetArm();
-            }
+            this->runPlannerAndLog();
+            this->resetArm();
 
             i++;
             if (i > num_runs_)
@@ -101,7 +98,7 @@ private:
         init_client_.call(empty_req);
     }
 
-    bool runPlannerAndLog()
+    void runPlannerAndLog()
     {
         planner::start_plan plan_req;
         plan_req.request.target = "cylinder";
@@ -134,8 +131,6 @@ private:
             ros::shutdown();
             exit(-1);
         }
-
-        return plan_req.response.path_found && plan_req.response.path_valid;
     }
 
     ros::NodeHandle nh_;

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -1,0 +1,163 @@
+#include <fstream>
+#include <random>
+#include <planner/start_plan.h>
+#include <gazebo_scene_randomiser_plugin/randomise.h>
+#include <gazebo_msgs/ModelStates.h>
+#include <gazebo_msgs/SetModelState.h>
+#include <ros/package.h>
+#include <boost/filesystem.hpp>
+#include "planner/util.h"
+#include "planner/defines.h"
+
+class Tester
+{
+public:
+    Tester(ros::NodeHandle* nh)
+        : nh_(*nh)
+    {
+        this->init();
+    }
+
+    ~Tester()
+    {
+
+    }
+
+    void run()
+    {
+        int i = 1;
+        while (ros::ok())
+        {
+            ROS_INFO("[TESTER]: Starting run #%d ...", i);
+
+            if (this->runPlannerAndLog())
+            {
+                // only reset if arm has actually moved to execute a plan
+                this->resetArm();
+            }
+
+            i++;
+            if (i > num_runs_)
+            {
+                ROS_INFO("%s[TESTER]: Test runs completed!", GREEN);
+                break;
+            }
+        }
+    }
+
+private:
+    void init()
+    {
+        planning_client_ = nh_.serviceClient<planner::start_plan>("/start_plan", 10);
+        randomiser_client_ = nh_.serviceClient<gazebo_scene_randomiser_plugin::randomise>("/gazebo/randomise_scene", 10);
+        open_gripper_client_ = nh_.serviceClient<std_srvs::Empty>("/open_gripper", 10);
+        init_client_ = nh_.serviceClient<std_srvs::Empty>("/go_to_init", 10);
+        home_client_ = nh_.serviceClient<std_srvs::Empty>("/go_to_home", 10);
+
+        while (!planning_client_.exists() && ros::ok())
+        {
+            ROS_WARN_THROTTLE(5, "planning service is not up! Waiting...");
+        }
+
+        ros::param::param<int>("~num_runs", num_runs_, 10);
+        ros::param::param<std::string>("~surface", surface_, "short_table_link_surface");
+        ros::param::param<std::string>("/robot_name", robot_name_, "j2s7s300");
+
+        if (num_runs_ <= 0)
+        {
+            ROS_FATAL("[TESTER]: Invalid number of runs! Value set: %d", num_runs_);
+            ros::shutdown();
+            exit(-1);
+        }
+        
+        auto time = std::time(nullptr);
+        std::stringstream ss;
+        ss << ros::package::getPath("planner") + "/test/logs/" << std::put_time(std::localtime(&time), "%b %d %Y")  << "/";
+        if (!boost::filesystem::exists(ss.str()))
+        {
+            if (!boost::filesystem::create_directories(ss.str()))
+            {
+                ROS_FATAL("Failed to create log directory!");
+                ros::shutdown();
+                exit(-1);
+            }
+        }
+
+        ss << std::put_time(std::localtime(&time), "%X") << ".log";
+
+        log_file_ = ss.str();
+
+        ROS_INFO("%s[TESTER]: Performing %d test runs!", BLUE, num_runs_);
+        ROS_INFO("%s[TESTER]: Saving log file to:\n%s", BLUE, log_file_.c_str());
+        
+        ROS_INFO("%s[TESTER]: Initialised!", GREEN);
+    }
+
+    void resetArm()
+    {
+        std_srvs::Empty empty_req;
+        open_gripper_client_.call(empty_req);
+        init_client_.call(empty_req);
+    }
+
+    bool runPlannerAndLog()
+    {
+        planner::start_plan plan_req;
+        plan_req.request.target = "cylinder";
+
+        gazebo_scene_randomiser_plugin::randomise randomise_req;
+        randomise_req.request.surface = surface_;
+        if (!randomiser_client_.call(randomise_req))
+        {
+            ROS_FATAL("Error calling randomiser service!");
+            ros::shutdown();
+            exit(-1);
+        }
+
+        if (planning_client_.call(plan_req))
+        {
+            std::fstream file;
+            file.open(log_file_, std::fstream::out);
+            
+            // annoyingly, bool variables in ROS srv/msg are represented as uint8, so each one needs to
+            // be cast to bool type to print them out correctly
+            file << std::boolalpha << bool(plan_req.response.path_found) << "," << bool(plan_req.response.path_valid) << ","
+                << bool(plan_req.response.grasp_success) << "," << plan_req.response.plan_time << std::endl;
+
+            file.flush();
+            file.close();
+        }
+        else
+        {
+            ROS_FATAL("[TESTER]: Encountered error while requesting a plan!");
+            ros::shutdown();
+            exit(-1);
+        }
+
+        return plan_req.response.path_found && plan_req.response.path_valid;
+    }
+
+    ros::NodeHandle nh_;
+    ros::ServiceClient planning_client_;
+    ros::ServiceClient randomiser_client_;
+    ros::ServiceClient open_gripper_client_;
+    ros::ServiceClient init_client_;
+    ros::ServiceClient home_client_;
+
+    int num_runs_;
+    std::string surface_;
+    std::string robot_name_;
+    std::string log_file_;
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "planner_test_node");
+    ros::NodeHandle nh;
+
+    Tester tester(&nh);
+    tester.run();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- Created a testing node to automate testing and logging, closes #19.
- added new response variables to start_plan srv for logging purposes.
- refactored code to move planning requests and collision geometries updating to Planner class as was originally desired in #16, this will help changing to online to planning for #23.
- Added grasp attempt verification.